### PR TITLE
Purge unused packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
  && pip install pyyaml \
 
  && apt-get purge -y python-pip \
+ && apt-get --purge autoremove \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD gitsplit /usr/local/bin/gitsplit


### PR DESCRIPTION
Playing with your docker image, and got a
```
The following packages were automatically installed and are no longer required:
  build-essential bzip2 cmake-data dpkg-dev fakeroot libalgorithm-diff-perl
  libalgorithm-diff-xs-perl libalgorithm-merge-perl libarchive13 libdpkg-perl
  libfakeroot libfile-fcntllock-perl libglib2.0-0 liblzo2-2 libtimedate-perl
  libxml2 python-cffi python-chardet python-colorama python-cryptography
  python-distlib python-html5lib python-ndg-httpsclient python-openssl
  python-pkg-resources python-ply python-pyasn1 python-pycparser python-requests
  python-setuptools python-support python-urllib3 python-wheel sgml-base xml-core
  xz-util
```