### PR TITLE
Use a decent git version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang
 
-RUN apt-get update \
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+ && apt-get update \
+ && apt-get install -y -t jessie-backports git \
  && apt-get install -y cmake pkg-config \
 
  && go get -d github.com/libgit2/git2go \


### PR DESCRIPTION
Using a decent git version (2.11, with debian backports), one could make use of ```GIT_SSH_COMMAND``` (git 2.3+) and get rid of ssh unknown hosts errors this way:
```
docker run [...] --env GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" [...] jderusse/gitsplit
```