### PR TITLE
Use pre-built binary instead of go compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,23 @@
-FROM golang
+FROM python:2-slim
+
+ENV SPLITSH_VERSION=1.0.1
 
 RUN apt-get update \
- && apt-get install -y cmake pkg-config \
+ && apt-get install -y curl \
 
- && go get -d github.com/libgit2/git2go \
- && cd $GOPATH/src/github.com/libgit2/git2go \
- && git checkout -f next \
- && git submodule update --init \
- && make install \
+ && curl -L https://github.com/splitsh/lite/releases/download/v${SPLITSH_VERSION}/lite_linux_amd64.tar.gz|tar zxf - && mv ./splitsh-lite /bin \
 
- && apt-get purge -y cmake pkg-config \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-
- && go get github.com/splitsh/lite \
- && go build -v -o /usr/local/bin/splitsh-lite github.com/splitsh/lite \
-
- && rm -rf /go/*
-
-RUN apt-get update \
- && apt-get install -y python-pip \
-
- && pip install pyyaml \
-
- && apt-get purge -y python-pip \
+ && apt-get purge --auto-remove -y curl \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+ && apt-get update \
+ && apt-get install -y -t jessie-backports \
+        git \
+
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN pip install pyyaml
 
 ADD gitsplit /usr/local/bin/gitsplit
 ENV PYTHONUNBUFFERED=0


### PR DESCRIPTION
This PR replace #2 by:
 - using pre-built binary of splitsh instead of building it
 - move base image to python:2-slim

It reduce size of image from 700Mo to 200
It also include #3 too