### PR TITLE
Deprecate git2go "next" branch and use static linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apk add --no-cache \
 
 RUN go get -d github.com/libgit2/git2go
 RUN cd $GOPATH/src/github.com/libgit2/git2go \
- && git checkout next \
  && git submodule update --init
 
 RUN apk add --no-cache \
@@ -13,7 +12,7 @@ RUN apk add --no-cache \
         cmake \
         g++
 RUN cd $GOPATH/src/github.com/libgit2/git2go \
- && make install
+ && make install-static
 
 COPY . /go/src/github.com/jderusse/gitsplit/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,22 @@ RUN apk add --no-cache \
 
 RUN go get -d github.com/libgit2/git2go
 RUN cd $GOPATH/src/github.com/libgit2/git2go \
- && git checkout v27 \
  && git submodule update --init
 
 RUN apk add --no-cache \
         make\
         cmake \
         g++ \
-        libressl-dev \
-        libssh2-dev \
-        libgit2-dev
+        openssl-dev \
+        libssh2-dev
 
 RUN cd $GOPATH/src/github.com/libgit2/git2go \
  && make install-static
 
 COPY . /go/src/github.com/jderusse/gitsplit/
 
-RUN go get github.com/jderusse/gitsplit
-RUN go build -o gitsplit github.com/jderusse/gitsplit
+RUN go get --tags "static" github.com/jderusse/gitsplit
+RUN go build --tags "static" -o gitsplit github.com/jderusse/gitsplit
 
 # ==================================================
 
@@ -30,6 +28,7 @@ FROM alpine
 
 RUN apk add --no-cache \
         git \
+        openssl \
         openssh-client \
         ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,17 @@ RUN apk add --no-cache \
 
 RUN go get -d github.com/libgit2/git2go
 RUN cd $GOPATH/src/github.com/libgit2/git2go \
+ && git checkout v27 \
  && git submodule update --init
 
 RUN apk add --no-cache \
         make\
         cmake \
-        g++
+        g++ \
+        libressl-dev \
+        libssh2-dev \
+        libgit2-dev
+
 RUN cd $GOPATH/src/github.com/libgit2/git2go \
  && make install-static
 


### PR DESCRIPTION
Git2go "next" branch is deprecated, and static linking is recommended for "master" branch.
See: https://github.com/libgit2/git2go#master-branch-or-static-linking

Some references:
* https://github.com/libgit2/git2go/pull/361
* https://github.com/libgit2/git2go/pull/362
* https://github.com/libgit2/git2go/pull/371
* https://github.com/libgit2/git2go/pull/413
