### PR TITLE
Fix missing libssh2 lib in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apk add --no-cache \
         git \
         openssl \
         openssh-client \
-        ca-certificates
+        ca-certificates \
+        libssh2-dev
 
 COPY --from=build /go/gitsplit /bin/gitsplit
 


### PR DESCRIPTION
After my README upate, a Docker hub build has been triggered and following failure was showing if we tried to use last image: 
```sh
docker run --rm -t -e GH_TOKEN -v ~/.cache/gitsplit:/cache/gitsplit -v ${PWD}:/srv jderusse/gitsplit gitsplit --ref "${CIRCLE_BRANCH}"
Error loading shared library libssh2.so.1: No such file or directory (needed by /bin/gitsplit)
```

This PR resolve this issue by adding libssh dependency in the Dockerfile.